### PR TITLE
Fixes the paths in the multi status error delete response.

### DIFF
--- a/src/main/java/nl/ellipsis/webdav/server/methods/DoDelete.java
+++ b/src/main/java/nl/ellipsis/webdav/server/methods/DoDelete.java
@@ -183,7 +183,7 @@ public class DoDelete extends AbstractMethod {
 					_store.removeObject(transaction, childPath);
 				}
 			} catch (Exception e) {
-			    if(!recordException(path + children[i], errorList, e)) {
+			    if(!recordException(path + "/" + children[i], errorList, e)) {
 			        throw e;
 			    }
 			}


### PR DESCRIPTION
It should have a path separator between the path and the child.